### PR TITLE
hotfix: creación/recepción de contraseña para la conexión del medidor

### DIFF
--- a/app/features/meters/__init__.py
+++ b/app/features/meters/__init__.py
@@ -134,7 +134,7 @@ async def connect(id_workspace: str,  id_meter: str, user=Depends(verify_access_
         raise HTTPException(status_code=500, detail="Server error")
 
 
-@meters_router.get("/receive/{password}/")
+@meters_router.post("/receive/{password}/")
 async def connect(password: int) -> WQMeterConnectResponse:
     try:
         meter = meter_connection.receive(password)

--- a/app/features/meters/domain/repository.py
+++ b/app/features/meters/domain/repository.py
@@ -26,6 +26,10 @@ class WaterQualityMeterRepository(ABC):
     def update(self, id_workspace: str, owner: str, id_meter: str, meter: WQMeterUpdate) -> WaterQualityMeter:
         pass
 
+    @abstractmethod
+    def is_active(self, id_workspace: str, owner: str, id_meter: str) -> bool:
+        pass
+
 
 class WaterQMSensor(ABC):
     @abstractmethod

--- a/app/features/meters/infrastructure/repo_meter_impl.py
+++ b/app/features/meters/infrastructure/repo_meter_impl.py
@@ -127,3 +127,8 @@ class WaterQualityMeterRepositoryImpl(WaterQualityMeterRepository):
             location=meter_update.get('location'),
             state=meter_update.get('state', MeterConnectionState.DISCONNECTED)
         )
+
+    def is_active(self, id_workspace: str, owner: str, id_meter: str) -> bool:
+        workspace_ref = self.get(id_workspace, owner, id_meter)
+
+        return workspace_ref.state == MeterConnectionState.CONNECTED or workspace_ref.state == MeterConnectionState.SENDING_DATA


### PR DESCRIPTION
Corrección para la creación y recepción de la contraseña para conectar el medidor con el espacio de trabajo