### PR TITLE
fix: renombrar variable 'user' a 'user_detail' 

### DIFF
--- a/app/features/workspaces/infrastructure/repo_impl.py
+++ b/app/features/workspaces/infrastructure/repo_impl.py
@@ -21,12 +21,12 @@ class WorkspaceRepositoryImpl(WorkspaceRepository):
 
         workspaces = []
         for workspace_id, data in workspaces_ref.get().items():
-            user = self.user_repo.get_by_uid(data.get('owner'))
+            user_detail = self.user_repo.get_by_uid(data.get('owner'))
             workspace = WorkspaceResponse(
                 id=workspace_id,
                 name=data.get('name'),
                 owner=data.get('owner'),
-                user=user,
+                user=user_detail,
                 type=data.get('type')
             )
             workspaces.append(workspace)
@@ -40,14 +40,14 @@ class WorkspaceRepositoryImpl(WorkspaceRepository):
 
         workspaces = []
         for workspace_id, data in workspaces_query.items():
-            user = self.user_repo.get_by_uid(data.get('owner'))
+            user_detail = self.user_repo.get_by_uid(data.get('owner'))
 
             workspace = WorkspaceResponse(
                 id=workspace_id,
                 name=data.get('name'),
                 owner=data.get('owner'),
                 type=data.get('type'),
-                user=user
+                user=user_detail
             )
             workspaces.append(workspace)
         return workspaces
@@ -115,14 +115,14 @@ class WorkspaceRepositoryImpl(WorkspaceRepository):
 
             workspace_data = workspace_ref.get()
 
-            user = self.user_repo.get_by_uid(workspace_data.get('owner'), limit_data=True)
+            user_detail = self.user_repo.get_by_uid(workspace_data.get('owner'), limit_data=True)
 
             workspace_list.append(WorkspaceShareResponse(
                 id=workspace_id,
                 name=workspace_data.get('name'),
                 owner=workspace_data.get('owner'),
                 guest=guest_user.email,
-                user=user,
+                user=user_detail,
                 rol=guest_data.get('rol'),
             ))
 


### PR DESCRIPTION
Renombre de variable en la consulta del espacio de trabajo, en la propiedad de usuario, se sobreescribía él, id de un usuario por el dato completo de todo un usuario