### PR TITLE
Refactor/sender alerts

### DIFF
--- a/app/features/alerts/domain/model.py
+++ b/app/features/alerts/domain/model.py
@@ -37,3 +37,10 @@ class AlertQueryParams(BaseModel):
     workspace_id: str | None = None
     meter_id: str | None = None
     type: AlertType | None = None
+
+
+class InfoForSendEmail(BaseModel):
+    workspace_name: str
+    meter_name: str
+    guests_emails: list[str]
+    meter_parameters: Parameter | None = None

--- a/app/features/alerts/domain/model.py
+++ b/app/features/alerts/domain/model.py
@@ -23,6 +23,7 @@ class AlertCreate(BaseModel):
     workspace_id: str
     meter_id: str
     parameters: Parameter
+    guests: list[str]
 
 
 class AlertUpdate(BaseModel):

--- a/app/features/alerts/domain/model.py
+++ b/app/features/alerts/domain/model.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from app.share.messages.domain.model import AlertType
+from app.share.messages.domain.model import AlertType, RecordParameter
 from app.share.parameters.domain.model import Parameter
 
 
@@ -43,4 +43,4 @@ class InfoForSendEmail(BaseModel):
     workspace_name: str
     meter_name: str
     guests_emails: list[str]
-    meter_parameters: Parameter | None = None
+    meter_parameters: list[RecordParameter] = []

--- a/app/features/alerts/domain/model.py
+++ b/app/features/alerts/domain/model.py
@@ -10,6 +10,7 @@ class AlertData(BaseModel):
     meter_id: str
     owner: str
     parameters: Parameter | None
+    guests: list[str]
 
 
 class Alert(AlertData):
@@ -28,6 +29,7 @@ class AlertUpdate(BaseModel):
     title: str
     type: AlertType
     parameters: Parameter | None = None
+    guests: list[str] | None = None
 
 
 class AlertQueryParams(BaseModel):

--- a/app/features/alerts/domain/repo.py
+++ b/app/features/alerts/domain/repo.py
@@ -5,6 +5,7 @@ from app.features.alerts.domain.model import (
     AlertCreate,
     AlertUpdate,
     AlertQueryParams,
+    InfoForSendEmail,
 )
 
 
@@ -31,4 +32,8 @@ class AlertRepository(ABC):
 
     @abstractmethod
     def delete(self, owner: str, alert_id: str) -> Alert:
+        pass
+
+    @abstractmethod
+    def get_info_for_send_email(self, alert_id: str) -> InfoForSendEmail:
         pass

--- a/app/features/alerts/infrastructure/repo_impl.py
+++ b/app/features/alerts/infrastructure/repo_impl.py
@@ -161,9 +161,10 @@ class AlertRepositoryImpl(AlertRepository):
 
         if alert.parameters is not None:
             # obtenemos los parámetros actuales y los actualizamos con los nuevos
-            current_parameters = alert_data.parameters.model_dump() or {}
-            current_parameters.update(alert.parameters)
-            alert.parameters = Parameter(**current_parameters)
+            if alert_data.parameters is not None:
+                current_parameters = alert_data.parameters.model_dump() or {}
+                current_parameters.update(alert.parameters)
+                alert.parameters = Parameter(**current_parameters)
         else:
             alert.parameters = alert_data.parameters
 

--- a/app/features/alerts/presentation/routes.py
+++ b/app/features/alerts/presentation/routes.py
@@ -103,9 +103,10 @@ async def update_notification_status(
             status_code=404, detail="La notificacion ya esta actualizada")
     info_for_send_email: InfoForSendEmail = alert_repo.get_info_for_send_email(
         alert_id=notification.alert_id)
+    info_for_send_email.meter_parameters = notification.record_parameters
     if info_for_send_email.guests_emails and status_body.status == NotificationStatus.ACCEPTED:
         body = html_template.get_critical_alert_notification_email(
-            approver_name=user.username or "Usuario", detected_values=info_for_send_email.meter_parameters.model_dump(), meter=info_for_send_email.meter_name,
+            approver_name=user.username or "Usuario", detected_values=info_for_send_email.meter_parameters, meter=info_for_send_email.meter_name,
             workspace=info_for_send_email.workspace_name)
         try:
             sender.send(

--- a/app/features/alerts/presentation/routes.py
+++ b/app/features/alerts/presentation/routes.py
@@ -118,7 +118,7 @@ async def update_notification_status(
                 status_code=ese.status_code, detail=ese.message)
 
     notifications_history_repo.update_notification_status(
-        notification_id, status_body.status)
+        notification_id, status_body.status, aproved_by=user.email)
 
     return {"message": "Notification status updated"}
 

--- a/app/share/email/infra/html_template.py
+++ b/app/share/email/infra/html_template.py
@@ -157,3 +157,80 @@ class HtmlTemplate:
             year=datetime.now().year,
         )
         return template
+
+    def get_critical_alert_notification_email(
+        self,
+        workspace_name: str,
+        meter_name: str,
+        alert_id: str,
+        detected_values: dict,
+        approver_name: str,
+    ) -> str:
+        """
+        Correo base que se enviará a Managers/Visitors cuando un admin/owner apruebe la alerta
+        (el contenido es preescrito; sólo cambian workspace, medidor y valores detectados).
+        """
+        year = datetime.now().year
+        template = Template("""
+        <html>
+          <head>
+            <meta charset="UTF-8" />
+            <title>Notificación: Alerta crítica aprobada</title>
+          </head>
+          <body style="font-family: Arial, sans-serif; background:#f4f6f8; padding:20px;">
+            <table width="100%" cellpadding="0" cellspacing="0" style="max-width:640px; margin:auto; background:white; border-radius:8px;">
+              <tr>
+                <td style="background:#145c57; padding:16px; color:white; text-align:center;">
+                  <h2 style="margin:0">Alerta crítica aprobada</h2>
+                </td>
+              </tr>
+
+              <tr>
+                <td style="padding:20px;">
+                  <p style="font-size:15px;">Hola,</p>
+                  <p style="font-size:14px; margin:6px 0;">
+                    Se ha aprobado una alerta crítica en el espacio <strong>${workspace}</strong> por <strong>${approver}</strong>.
+                  </p>
+
+                  <p style="font-size:14px; margin:8px 0;"><strong>Medidor:</strong> ${meter}</p>
+
+                  <p style="font-size:14px; margin:8px 0;"><strong>Valores detectados:</strong></p>
+                  <table cellpadding="8" cellspacing="0" width="100%" style="border:1px solid #e9e9e9; border-collapse:collapse;">
+                    <thead style="background:#f7f7f7;">
+                      <tr><th align="left">Parámetro</th><th align="left">Valor</th></tr>
+                    </thead>
+                    <tbody>
+                      ${detected_rows}
+                    </tbody>
+                  </table>
+
+                  <div style="text-align:center; margin-top:18px;">
+                    <a href="${view_url}" target="_blank" style="display:inline-block; padding:10px 18px; border-radius:6px; background:#145c57; color:white; text-decoration:none;">Ver detalle de la alerta</a>
+                  </div>
+                </td>
+              </tr>
+
+              <tr>
+                <td style="background:#fafafa; text-align:center; padding:12px; font-size:12px; color:#999;">
+                  © ${year} aqua-minds.org
+                </td>
+              </tr>
+            </table>
+          </body>
+        </html>
+        """)
+
+        rows = []
+        for k, v in detected_values.items():
+            rows.append(
+                f"<tr><td style='border-top:1px solid #eee;'>{k}</td><td style='border-top:1px solid #eee;'>{v}</td></tr>")
+        detected_rows = "\n".join(rows)
+
+        return template.substitute(
+            workspace=workspace_name,
+            meter=meter_name,
+            alert_id=alert_id,
+            detected_rows=detected_rows,
+            approver=approver_name,
+            year=year,
+        )

--- a/app/share/email/infra/html_template.py
+++ b/app/share/email/infra/html_template.py
@@ -1,6 +1,8 @@
 from string import Template
 from datetime import datetime
 
+from app.share.messages.domain.model import RecordParameter
+
 
 class HtmlTemplate:
 
@@ -162,7 +164,7 @@ class HtmlTemplate:
         self,
         workspace: str,
         meter: str,
-        detected_values: dict,
+        detected_values: list[RecordParameter],
         approver_name: str,
     ) -> str:
         """
@@ -216,9 +218,9 @@ class HtmlTemplate:
         """)
 
         rows = []
-        for k, v in detected_values.items():
+        for record in detected_values:
             rows.append(
-                f"<tr><td style='border-top:1px solid #eee;'>{k}</td><td style='border-top:1px solid #eee;'>{v}</td></tr>")
+                f"<tr><td style='border-top:1px solid #eee;'>{record.parameter}</td><td style='border-top:1px solid #eee;'>{record.value}</td></tr>")
         detected_rows = "\n".join(rows)
         template = template.substitute(
             workspace=workspace,

--- a/app/share/email/infra/html_template.py
+++ b/app/share/email/infra/html_template.py
@@ -162,7 +162,6 @@ class HtmlTemplate:
         self,
         workspace_name: str,
         meter_name: str,
-        alert_id: str,
         detected_values: dict,
         approver_name: str,
     ) -> str:
@@ -229,7 +228,6 @@ class HtmlTemplate:
         return template.substitute(
             workspace=workspace_name,
             meter=meter_name,
-            alert_id=alert_id,
             detected_rows=detected_rows,
             approver=approver_name,
             year=year,

--- a/app/share/email/infra/html_template.py
+++ b/app/share/email/infra/html_template.py
@@ -160,8 +160,8 @@ class HtmlTemplate:
 
     def get_critical_alert_notification_email(
         self,
-        workspace_name: str,
-        meter_name: str,
+        workspace: str,
+        meter: str,
         detected_values: dict,
         approver_name: str,
     ) -> str:
@@ -188,7 +188,7 @@ class HtmlTemplate:
                 <td style="padding:20px;">
                   <p style="font-size:15px;">Hola,</p>
                   <p style="font-size:14px; margin:6px 0;">
-                    Se ha aprobado una alerta crítica en el espacio <strong>${workspace}</strong> por <strong>${approver}</strong>.
+                    Se ha aprobado una alerta crítica en el espacio <strong>${workspace}</strong> por <strong>${approver_name}</strong>.
                   </p>
 
                   <p style="font-size:14px; margin:8px 0;"><strong>Medidor:</strong> ${meter}</p>
@@ -202,10 +202,6 @@ class HtmlTemplate:
                       ${detected_rows}
                     </tbody>
                   </table>
-
-                  <div style="text-align:center; margin-top:18px;">
-                    <a href="${view_url}" target="_blank" style="display:inline-block; padding:10px 18px; border-radius:6px; background:#145c57; color:white; text-decoration:none;">Ver detalle de la alerta</a>
-                  </div>
                 </td>
               </tr>
 
@@ -224,11 +220,12 @@ class HtmlTemplate:
             rows.append(
                 f"<tr><td style='border-top:1px solid #eee;'>{k}</td><td style='border-top:1px solid #eee;'>{v}</td></tr>")
         detected_rows = "\n".join(rows)
-
-        return template.substitute(
-            workspace=workspace_name,
-            meter=meter_name,
+        template = template.substitute(
+            workspace=workspace,
+            meter=meter,
             detected_rows=detected_rows,
-            approver=approver_name,
-            year=year,
+            approver_name=approver_name,
+            year=year
         )
+
+        return template

--- a/app/share/messages/domain/model.py
+++ b/app/share/messages/domain/model.py
@@ -13,6 +13,12 @@ class AlertType(str, Enum):
     EXCELLENT = "excellent"
 
 
+class NotificationStatus(str, Enum):
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    PENDING = "pending"
+
+
 class ResultValidationAlert(BaseModel):
     alerts_ids: list[str] = []
     has_parameters: bool = False
@@ -44,6 +50,7 @@ class NotificationBody(BaseModel):
     body: str
     user_ids: list[str]
     timestamp: float | None = None
+    status: NotificationStatus | None = None
 
 
 class NotificationBodyDatetime(BaseModel):
@@ -53,6 +60,7 @@ class NotificationBodyDatetime(BaseModel):
     body: str
     user_id: str
     datetime: str | float = None
+    status: NotificationStatus | None = None
 
 
 class QueryNotificationParams(BaseModel):

--- a/app/share/messages/domain/model.py
+++ b/app/share/messages/domain/model.py
@@ -23,13 +23,25 @@ class NotificationStatusData(BaseModel):
     status: NotificationStatus
 
 
+class ParameterDataForAlert(BaseModel):
+    alert_id: str
+    parameter: str
+    value: float
+
+
 class ResultValidationAlert(BaseModel):
     alerts_ids: list[str] = []
     has_parameters: bool = False
+    parameters_data: list[ParameterDataForAlert] = []
 
 
 class PriorityParameters(list[str], Enum):
     parameters: list[str] = ["ph", "turbidity"]
+
+
+class RecordParameter(BaseModel):
+    parameter: str
+    value: float
 
 
 class AlertData(BaseModel):
@@ -39,6 +51,7 @@ class AlertData(BaseModel):
     type: AlertType
     user_uid: str
     parameters: Parameter | None = None
+    records_of_parameters: list[RecordParameter] = []
 
 
 class NotificationControl(BaseModel):
@@ -56,6 +69,7 @@ class NotificationBody(BaseModel):
     timestamp: float | None = None
     status: NotificationStatus | None = None
     alert_id: str | None = None
+    record_parameters: list[RecordParameter] = []
 
 
 class NotificationBodyDatetime(BaseModel):

--- a/app/share/messages/domain/model.py
+++ b/app/share/messages/domain/model.py
@@ -70,6 +70,7 @@ class NotificationBody(BaseModel):
     status: NotificationStatus | None = None
     alert_id: str | None = None
     record_parameters: list[RecordParameter] = []
+    aproved_by: str | None = None
 
 
 class NotificationBodyDatetime(BaseModel):

--- a/app/share/messages/domain/model.py
+++ b/app/share/messages/domain/model.py
@@ -42,7 +42,7 @@ class NotificationBody(BaseModel):
     read: bool = False
     title: str
     body: str
-    user_id: str
+    user_ids: list[str]
     timestamp: float | None = None
 
 

--- a/app/share/messages/domain/model.py
+++ b/app/share/messages/domain/model.py
@@ -19,6 +19,10 @@ class NotificationStatus(str, Enum):
     PENDING = "pending"
 
 
+class NotificationStatusData(BaseModel):
+    status: NotificationStatus
+
+
 class ResultValidationAlert(BaseModel):
     alerts_ids: list[str] = []
     has_parameters: bool = False
@@ -51,6 +55,7 @@ class NotificationBody(BaseModel):
     user_ids: list[str]
     timestamp: float | None = None
     status: NotificationStatus | None = None
+    alert_id: str | None = None
 
 
 class NotificationBodyDatetime(BaseModel):

--- a/app/share/messages/domain/repo.py
+++ b/app/share/messages/domain/repo.py
@@ -10,7 +10,7 @@ class SenderAlertsRepository(ABC):
     """
 
     @abstractmethod
-    def send_alerts(self, meter_id: str, record: RecordBody) -> None:
+    def send_alerts(self, workspace_id: str, meter_id: str, record: RecordBody) -> None:
         """
         Mark alerts as seen for a specific meter.
         :param meter_id: The ID of the meter.

--- a/app/share/messages/domain/repo.py
+++ b/app/share/messages/domain/repo.py
@@ -62,7 +62,7 @@ class NotificationManagerRepository(ABC):
         pass
 
     @abstractmethod
-    def update_notification_status(self, notification_id: str, status: str):
+    def update_notification_status(self, notification_id: str, status: str, aproved_by: str):
         pass
 
     @abstractmethod

--- a/app/share/messages/domain/repo.py
+++ b/app/share/messages/domain/repo.py
@@ -60,3 +60,11 @@ class NotificationManagerRepository(ABC):
     @abstractmethod
     def update_control_last_sent(self, alert_id: str, last_sent: float):
         pass
+
+    @abstractmethod
+    def update_notification_status(self, notification_id: str, status: str):
+        pass
+
+    @abstractmethod
+    def get_by_id(self, notification_id: str) -> NotificationBody:
+        pass

--- a/app/share/messages/domain/validate.py
+++ b/app/share/messages/domain/validate.py
@@ -1,5 +1,5 @@
 from app.share.socketio.domain.model import RecordBody
-from app.share.messages.domain.model import AlertData, PriorityParameters, ResultValidationAlert
+from app.share.messages.domain.model import AlertData, PriorityParameters, ResultValidationAlert, ParameterDataForAlert
 from app.share.meter_records.domain.enums import SensorType
 
 
@@ -35,9 +35,25 @@ class RecordValidation:
                     continue
                 if param in PriorityParameters.parameters:
                     result_validation_alert.alerts_ids.append(alert.id)
-                    break
+                    result_validation_alert.parameters_data.append(
+                        ParameterDataForAlert(
+                            alert_id=alert.id,
+                            parameter=param,
+                            value=sensor_value
+                        )
+                    )
+                    continue
                 valid_params_count += 1
+                result_validation_alert.parameters_data.append(
+                    ParameterDataForAlert(
+                        alert_id=alert.id,
+                        parameter=param,
+                        value=sensor_value
+                    )
+                )
             if valid_params_count >= 3:
                 result_validation_alert.alerts_ids.append(alert.id)
-
+        # Eliminar ids duplicados
+        result_validation_alert.alerts_ids = list(
+            set(result_validation_alert.alerts_ids))
         return result_validation_alert

--- a/app/share/messages/infra/notification_manager.py
+++ b/app/share/messages/infra/notification_manager.py
@@ -130,7 +130,7 @@ class NotificationManagerRepositoryImpl(NotificationManagerRepository):
 
         ref.set(last_sent)
 
-    def update_notification_status(self, notification_id: str, status: str):
+    def update_notification_status(self, notification_id: str, status: str, aproved_by: str):
         notification_ref = db.reference(
             f"/notifications_history/{notification_id}/")
 
@@ -140,7 +140,7 @@ class NotificationManagerRepositoryImpl(NotificationManagerRepository):
             raise ValueError(
                 f"Notification with ID {notification_id} not found.")
 
-        notification_ref.update({"status": status})
+        notification_ref.update({"status": status, "aproved_by": aproved_by})
 
     def get_by_id(self, notification_id: str) -> NotificationBody:
         notification_ref = db.reference(

--- a/app/share/messages/infra/notification_manager.py
+++ b/app/share/messages/infra/notification_manager.py
@@ -60,7 +60,8 @@ class NotificationManagerRepositoryImpl(NotificationManagerRepository):
                     title=notification_data.get("title"),
                     body=notification_data.get("body"),
                     user_id=notification_data.get("user_id"),
-                    datetime=notification_data.get("timestamp")
+                    datetime=notification_data.get("timestamp"),
+                    status=notification_data.get("status") or None
                 )
             else:
                 notification = NotificationBody(**notification_data)

--- a/app/share/messages/infra/notification_manager.py
+++ b/app/share/messages/infra/notification_manager.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import time
 from firebase_admin import db
-from app.share.messages.domain.model import NotificationBody, NotificationBodyDatetime, NotificationControl, QueryNotificationParams
+from app.share.messages.domain.model import NotificationBody, NotificationBodyDatetime, NotificationControl, QueryNotificationParams, RecordParameter
 from app.share.messages.domain.repo import NotificationManagerRepository
 
 
@@ -152,6 +152,24 @@ class NotificationManagerRepositoryImpl(NotificationManagerRepository):
             raise ValueError(
                 f"Notification with ID {notification_id} not found.")
 
-        notification = NotificationBody(**notification_data)
-        notification.id = notification_id
+        pre_record_parameters = notification_data.get(
+            "record_parameters") or None
+        record_parameters = []
+        if pre_record_parameters is not None:
+            for record in pre_record_parameters.values():
+                record_parameters.append(
+                    RecordParameter(**record)
+                )
+
+        notification = NotificationBody(
+            id=notification_id,
+            read=notification_data.get("read"),
+            title=notification_data.get("title"),
+            body=notification_data.get("body"),
+            user_ids=notification_data.get("user_ids"),
+            timestamp=notification_data.get("timestamp"),
+            status=notification_data.get("status"),
+            alert_id=notification_data.get("alert_id"),
+            record_parameters=record_parameters
+        )
         return notification

--- a/app/share/messages/infra/notification_manager.py
+++ b/app/share/messages/infra/notification_manager.py
@@ -156,9 +156,10 @@ class NotificationManagerRepositoryImpl(NotificationManagerRepository):
             "record_parameters") or None
         record_parameters = []
         if pre_record_parameters is not None:
-            for record in pre_record_parameters.values():
+            for record in pre_record_parameters:
                 record_parameters.append(
-                    RecordParameter(**record)
+                    RecordParameter(parameter=record.get(
+                        "parameter"), value=record.get("value"))
                 )
 
         notification = NotificationBody(

--- a/app/share/messages/infra/notification_manager.py
+++ b/app/share/messages/infra/notification_manager.py
@@ -129,3 +129,29 @@ class NotificationManagerRepositoryImpl(NotificationManagerRepository):
             f'/notifications_control/{alert_id}/last_sent')
 
         ref.set(last_sent)
+
+    def update_notification_status(self, notification_id: str, status: str):
+        notification_ref = db.reference(
+            f"/notifications_history/{notification_id}/")
+
+        notification_data = notification_ref.get()
+
+        if notification_data is None:
+            raise ValueError(
+                f"Notification with ID {notification_id} not found.")
+
+        notification_ref.update({"status": status})
+
+    def get_by_id(self, notification_id: str) -> NotificationBody:
+        notification_ref = db.reference(
+            f"/notifications_history/{notification_id}/")
+
+        notification_data = notification_ref.get()
+
+        if notification_data is None:
+            raise ValueError(
+                f"Notification with ID {notification_id} not found.")
+
+        notification = NotificationBody(**notification_data)
+        notification.id = notification_id
+        return notification

--- a/app/share/messages/infra/sender_alerts.py
+++ b/app/share/messages/infra/sender_alerts.py
@@ -128,7 +128,8 @@ class SenderAlertsRepositoryImpl(SenderAlertsRepository):
                 body=f"Alert Type {alert.type.value.capitalize()} for meter {alert.meter_id}",
                 user_ids=recipients,
                 timestamp=time.time(),
-                status=NotificationStatus.PENDING
+                status=NotificationStatus.PENDING,
+                alert_id=alert.id
             )
 
             await self.sender_service.send_notification(notification)

--- a/app/share/messages/infra/sender_alerts.py
+++ b/app/share/messages/infra/sender_alerts.py
@@ -37,7 +37,7 @@ class SenderAlertsRepositoryImpl(SenderAlertsRepository):
     def _get_owner_of_workspace(self, workspace_id: str) -> str:
         ref = db.reference().child("workspaces").child(workspace_id).child("owner")
         owner_data = ref.get()
-        return list(owner_data.keys())[0]
+        return owner_data
 
     def _get_managers_of_workspace(self, workspace_id: str) -> list[str]:
         ref = db.reference().child("workspaces").child(workspace_id).child("guests")

--- a/app/share/messages/infra/sender_alerts.py
+++ b/app/share/messages/infra/sender_alerts.py
@@ -1,7 +1,7 @@
 from firebase_admin import db
 import time
 from datetime import datetime, timezone
-from app.share.messages.domain.model import AlertData, NotificationControl,  NotificationBody
+from app.share.messages.domain.model import AlertData, NotificationControl,  NotificationBody, NotificationStatus
 from app.share.messages.domain.repo import NotificationManagerRepository, SenderAlertsRepository, SenderServiceRepository
 from app.share.messages.domain.validate import RecordValidation
 from app.share.socketio.domain.model import RecordBody
@@ -127,7 +127,8 @@ class SenderAlertsRepositoryImpl(SenderAlertsRepository):
                 title=alert.title,
                 body=f"Alert Type {alert.type.value.capitalize()} for meter {alert.meter_id}",
                 user_ids=recipients,
-                timestamp=time.time()
+                timestamp=time.time(),
+                status=NotificationStatus.PENDING
             )
 
             await self.sender_service.send_notification(notification)

--- a/app/share/messages/service/onesignal_service.py
+++ b/app/share/messages/service/onesignal_service.py
@@ -30,8 +30,7 @@ class OneSignalService(SenderServiceRepository):
             app_id=self.config.app_id,
             headings=StringMap(en=notification.title),
             contents=StringMap(en=notification.body),
-            include_external_user_ids=[
-                notification.user_id],  # Debe ser una lista
+            include_external_user_ids=notification.user_ids,  # Debe ser una lista
         )
 
     async def send_notification(self, notification: NotificationBody):

--- a/app/share/socketio/__init__.py
+++ b/app/share/socketio/__init__.py
@@ -49,7 +49,8 @@ async def receive_connection(sid, environ):
 
         query_dict = query_string_to_dict(environ.get("QUERY_STRING") or "")
 
-        token = environ.get("HTTP_ACCESS_TOKEN") or query_dict.get("access_token")
+        token = environ.get(
+            "HTTP_ACCESS_TOKEN") or query_dict.get("access_token")
 
         if not token:
             raise Exception("Access token is required")
@@ -92,7 +93,7 @@ async def receive_message(sid, data: dict):
         background_tasks.add_task(
             sender.send_alerts, payload.id_meter, record_body)
         """
-        await sender.send_alerts(meter_id=payload.id_meter, records=record_body)
+        await sender.send_alerts(workspace_id=payload.id_workspace, meter_id=payload.id_meter, records=record_body)
         await sio.emit(
             "message",
             response.model_dump(mode="json"),
@@ -135,7 +136,8 @@ async def subscribe_connection(sid, environ):
         print(f"📡 Nuevo conexión en subscribe: {sid}")
         query_dict = query_string_to_dict(environ.get("QUERY_STRING") or "")
 
-        token = environ.get("HTTP_ACCESS_TOKEN") or query_dict.get("access_token")
+        token = environ.get(
+            "HTTP_ACCESS_TOKEN") or query_dict.get("access_token")
 
         if not token:
             raise Exception("Access token is required")
@@ -169,7 +171,8 @@ async def subscribe_connection(sid, environ):
 
         # Crear la sala con el email del usuario
         await sio.enter_room(sid, room_name, namespace="/subscribe/")
-        print(f"🔗 Cliente {sid} unido a la sala {room_name} en namespace /subscribe/")
+        print(
+            f"🔗 Cliente {sid} unido a la sala {room_name} en namespace /subscribe/")
 
     except Exception as e:
         print(e.__class__.__name__)


### PR DESCRIPTION
Se implemento  el flujo de validación manual para alertas críticas: al generarse, las alertas quedan primero en estado pendiente de validación y son asignadas únicamente a los administradores y owners del espacio de trabajo. Un administrador/owner puede revisar los registros que originaron la alerta y aprobar o descartar la notificación al resto del espacio (rol Visitor).